### PR TITLE
feat: add padding stylus mixin

### DIFF
--- a/packages/stylus/index.styl
+++ b/packages/stylus/index.styl
@@ -1,1 +1,3 @@
-@import "margin"
+@import 'margin'
+
+@import 'padding'

--- a/packages/stylus/padding.styl
+++ b/packages/stylus/padding.styl
@@ -1,0 +1,102 @@
+// All props are optional and default to false
+padding(block = false, blockEnd = false, blockStart = false, inline = false, inlineEnd = false, inlineStart = false, padding = false, scroll = false, scrollBlock = false, scrollBlockEnd = false, scrollBlockStart = false, scrollInline = false, scrollInlineEnd = false, scrollInlineStart = false) {
+  // Wrap each property in a conditional to avoid empty/invalid styles from being generated
+  // General value that apply to more than one side
+  if padding {
+    padding padding
+  }
+
+  if block {
+    padding-block block
+  }
+
+  if inline {
+    padding-inline inline
+  }
+
+  // Side specific values to overwrite any general or axis values
+  if blockEnd {
+    padding-block-end blockEnd
+  }
+
+  if blockStart {
+    padding-block-start blockStart
+  }
+
+  if inlineEnd {
+    padding-inline-end inlineEnd
+  }
+
+  if inlineStart {
+    padding-inline-start inlineStart
+  }
+
+  // General scroll values that apply to more than one side
+  if scroll {
+    scroll-padding scroll
+  }
+
+  // Axis specific values to apply to two sides
+  if scrollBlock {
+    scroll-padding-block scrollBlock
+  }
+
+  if scrollInline {
+    scroll-padding-inline scrollInline
+  }
+
+  // Side specific scroll values to overwrite any general or axis values
+  if scrollBlockEnd {
+    scroll-padding-block-end scrollBlockEnd
+  }
+
+  if scrollBlockStart {
+    scroll-padding-block-start scrollBlockStart
+  }
+
+  if scrollInlineEnd {
+    scroll-padding-inline-end scrollInlineEnd
+  }
+
+  if scrollInlineStart {
+    scroll-padding-inline-start scrollInlineStart
+  }
+
+  @supports not (padding-block-end 1rem) {
+    // Side-specific fallbacks or axis-specific fallbacks
+    if (blockStart || (block[0])) {
+      padding-top: blockStart || (block[0])
+    }
+
+    if (blockEnd || (block[1])) {
+      padding-bottom: blockEnd || (block[1])
+    }
+
+    if (inlineStart || (inline[0])) {
+      padding-left: inlineStart || (inline[0])
+    }
+
+    if (inlineEnd || (inline[1])) {
+      padding-right: inlineEnd || (inline[1])
+    }
+  }
+
+  @supports not (scroll-padding-block 1rem) {
+    // Side-specific fallbacks or axis-specific fallbacks
+    if (scrollBlockStart || (scrollBlock[0])) {
+      scroll-padding-top: scrollBlockStart || (scrollBlock[0])
+    }
+
+    if (scrollBlockEnd || (scrollBlock[1])) {
+      scroll-padding-bottom: scrollBlockEnd || (scrollBlock[1])
+    }
+
+    if (scrollInlineStart || (scrollInline[0])) {
+      scroll-padding-left: scrollInlineStart || (scrollInline[0])
+    }
+
+    if (scrollInlineEnd || (scrollInline[1])) {
+      scroll-padding-right: scrollInlineEnd || (scrollInline[1])
+    }
+  }
+}


### PR DESCRIPTION
## 🔐 Closes

N/A

## 🚀 Changes

- adds padding mixin to stylus package
- adds padding mixin to root index file

## ⛳️ Testing

- wrote and tested mixin at [Try Stylus](https://stylus-lang.com/try.html#?code=%2F%2F%20All%20props%20are%20optional%20and%20default%20to%20false%0Apadding(block%20%3D%20false%2C%20blockEnd%20%3D%20false%2C%20blockStart%20%3D%20false%2C%20inline%20%3D%20false%2C%20inlineEnd%20%3D%20false%2C%20inlineStart%20%3D%20false%2C%20padding%20%3D%20false%2C%20scroll%20%3D%20false%2C%20scrollBlock%20%3D%20false%2C%20scrollBlockEnd%20%3D%20false%2C%20scrollBlockStart%20%3D%20false%2C%20scrollInline%20%3D%20false%2C%20scrollInlineEnd%20%3D%20false%2C%20scrollInlineStart%20%3D%20false)%20%7B%0A%20%20%2F%2F%20Wrap%20each%20property%20in%20a%20conditional%20to%20avoid%20empty%2Finvalid%20styles%20from%20being%20generated%0A%20%20%2F%2F%20General%20value%20that%20apply%20to%20more%20than%20one%20side%0A%20%20if%20padding%20%7B%0A%20%20%20%20padding%20padding%0A%20%20%7D%0A%0A%20%20if%20block%20%7B%0A%20%20%20%20padding-block%20block%0A%20%20%7D%0A%0A%20%20if%20inline%20%7B%0A%20%20%20%20padding-inline%20inline%0A%20%20%7D%0A%0A%20%20%2F%2F%20Side%20specific%20values%20to%20overwrite%20any%20general%20or%20axis%20values%0A%20%20if%20blockEnd%20%7B%0A%20%20%20%20padding-block-end%20blockEnd%0A%20%20%7D%0A%0A%20%20if%20blockStart%20%7B%0A%20%20%20%20padding-block-start%20blockStart%0A%20%20%7D%0A%0A%20%20if%20inlineEnd%20%7B%0A%20%20%20%20padding-inline-end%20inlineEnd%0A%20%20%7D%0A%0A%20%20if%20inlineStart%20%7B%0A%20%20%20%20padding-inline-start%20inlineStart%0A%20%20%7D%0A%0A%20%20%2F%2F%20General%20scroll%20values%20that%20apply%20to%20more%20than%20one%20side%0A%20%20if%20scroll%20%7B%0A%20%20%20%20scroll-padding%20scroll%0A%20%20%7D%0A%0A%20%20%2F%2F%20Axis%20specific%20values%20to%20apply%20to%20two%20sides%0A%20%20if%20scrollBlock%20%7B%0A%20%20%20%20scroll-padding-block%20scrollBlock%0A%20%20%7D%0A%0A%20%20if%20scrollInline%20%7B%0A%20%20%20%20scroll-padding-inline%20scrollInline%0A%20%20%7D%0A%0A%20%20%2F%2F%20Side%20specific%20scroll%20values%20to%20overwrite%20any%20general%20or%20axis%20values%0A%20%20if%20scrollBlockEnd%20%7B%0A%20%20%20%20scroll-padding-block-end%20scrollBlockEnd%0A%20%20%7D%0A%0A%20%20if%20scrollBlockStart%20%7B%0A%20%20%20%20scroll-padding-block-start%20scrollBlockStart%0A%20%20%7D%0A%0A%20%20if%20scrollInlineEnd%20%7B%0A%20%20%20%20scroll-padding-inline-end%20scrollInlineEnd%0A%20%20%7D%0A%0A%20%20if%20scrollInlineStart%20%7B%0A%20%20%20%20scroll-padding-inline-start%20scrollInlineStart%0A%20%20%7D%0A%0A%20%20%40supports%20not%20(padding-block-end%201rem)%20%7B%0A%20%20%20%20%2F%2F%20Side-specific%20fallbacks%20or%20axis-specific%20fallbacks%0A%20%20%20%20if%20(blockStart%20%7C%7C%20(block%5B0%5D))%20%7B%0A%20%20%20%20%20%20padding-top%3A%20blockStart%20%7C%7C%20(block%5B0%5D)%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(blockEnd%20%7C%7C%20(block%5B1%5D))%20%7B%0A%20%20%20%20%20%20padding-bottom%3A%20blockEnd%20%7C%7C%20(block%5B1%5D)%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(inlineStart%20%7C%7C%20(inline%5B0%5D))%20%7B%0A%20%20%20%20%20%20padding-left%3A%20inlineStart%20%7C%7C%20(inline%5B0%5D)%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(inlineEnd%20%7C%7C%20(inline%5B1%5D))%20%7B%0A%20%20%20%20%20%20padding-right%3A%20inlineEnd%20%7C%7C%20(inline%5B1%5D)%0A%20%20%20%20%7D%0A%20%20%7D%0A%0A%20%20%40supports%20not%20(scroll-padding-block%201rem)%20%7B%0A%20%20%20%20%2F%2F%20Side-specific%20fallbacks%20or%20axis-specific%20fallbacks%0A%20%20%20%20if%20(scrollBlockStart%20%7C%7C%20(scrollBlock%5B0%5D))%20%7B%0A%20%20%20%20%20%20scroll-padding-top%3A%20scrollBlockStart%20%7C%7C%20(scrollBlock%5B0%5D)%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(scrollBlockEnd%20%7C%7C%20(scrollBlock%5B1%5D))%20%7B%0A%20%20%20%20%20%20scroll-padding-bottom%3A%20scrollBlockEnd%20%7C%7C%20(scrollBlock%5B1%5D)%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(scrollInlineStart%20%7C%7C%20(scrollInline%5B0%5D))%20%7B%0A%20%20%20%20%20%20scroll-padding-left%3A%20scrollInlineStart%20%7C%7C%20(scrollInline%5B0%5D)%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(scrollInlineEnd%20%7C%7C%20(scrollInline%5B1%5D))%20%7B%0A%20%20%20%20%20%20scroll-padding-right%3A%20scrollInlineEnd%20%7C%7C%20(scrollInline%5B1%5D)%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0A%0A.containr%20%7B%0A%20padding(scrollInline%3A%20inherit%20unset%2C%20padding%3A%2010px%2C%20block%3A%201rem%202rem%2C%20inline%3A%205rem%2011rem)%20%0A%7D) to verify output
