### PR TITLE
feat: add stylus border radius mixin

### DIFF
--- a/packages/stylus/borderRadius.styl
+++ b/packages/stylus/borderRadius.styl
@@ -1,0 +1,43 @@
+// All props are optional and default to false
+border-radius(bottomLeft = false, bottomRight = false, radius = false, topLeft = false, topRight = false) {
+    // General value that apply to more than one side
+    if radius {
+        border-radius radius
+    }
+
+    // Side specific values to overwrite any general values
+    if bottomRight {
+        border-end-end-radius bottomRight
+    }
+
+    if bottomLeft {
+        border-end-start-radius bottomLeft
+    }
+
+    if topRight {
+        border-start-end-radius topRight
+    }
+
+    if topLeft {
+        border-start-start-radius topLeft
+    }
+
+    @supports not (border-end-end-radius 1rem) {
+        // Side-specific fallbacks to override any general values
+        if bottomRight {
+            border-bottom-right-radius bottomRight
+        }
+
+        if bottomLeft {
+            border-bottom-left-radius bottomLeft
+        }
+
+        if topRight {
+            border-top-right-radius topRight
+        }
+
+        if topLeft {
+            border-top-left-radius topLeft
+        }
+    }
+}

--- a/packages/stylus/index.styl
+++ b/packages/stylus/index.styl
@@ -1,3 +1,5 @@
+@import 'borderRadius'
+
 @import 'margin'
 
 @import 'padding'


### PR DESCRIPTION
## 🔐 Closes

N/A

## 🚀 Changes

- adds border radius mixin to stylus package
- adds border radius import to root index file

## ⛳️ Testing

- wrote and tested code at [Try Stylus](https://stylus-lang.com/try.html#?code=%2F%2F%20All%20props%20are%20optional%20and%20default%20to%20false%0Aborder-radius(bottomLeft%20%3D%20false%2C%20bottomRight%20%3D%20false%2C%20radius%20%3D%20false%2C%20topLeft%20%3D%20false%2C%20topRight%20%3D%20false)%20%7B%0A%20%20%20%20%2F%2F%20General%20value%20that%20apply%20to%20more%20than%20one%20side%0A%20%20%20%20if%20radius%20%7B%0A%20%20%20%20%20%20%20%20border-radius%20radius%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%20Side%20specific%20values%20to%20overwrite%20any%20general%20values%0A%20%20%20%20if%20bottomRight%20%7B%0A%20%20%20%20%20%20%20%20border-end-end-radius%20bottomRight%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20bottomLeft%20%7B%0A%20%20%20%20%20%20%20%20border-end-start-radius%20bottomLeft%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20topRight%20%7B%0A%20%20%20%20%20%20%20%20border-start-end-radius%20topRight%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20topLeft%20%7B%0A%20%20%20%20%20%20%20%20border-start-start-radius%20topLeft%0A%20%20%20%20%7D%0A%0A%20%20%20%20%40supports%20not%20(border-end-end-radius%201rem)%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Side-specific%20fallbacks%20to%20override%20any%20general%20values%0A%20%20%20%20%20%20%20%20if%20bottomRight%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20border-bottom-right-radius%20bottomRight%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20bottomLeft%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20border-bottom-left-radius%20bottomLeft%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20topRight%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20border-top-right-radius%20topRight%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20topLeft%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20border-top-left-radius%20topLeft%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%0A.containr%20%7B%0A%20border-radius(radius%3A%201rem%2C%20topLeft%3A%2010px%2C%20bottomRight%3A%201rem)%20%0A%7D) to verify output