### PR TITLE
Feat/stylus/position

### DIFF
--- a/packages/stylus/border.styl
+++ b/packages/stylus/border.styl
@@ -115,71 +115,71 @@ border(border = false, borderColor = false, borderStyle = false, borderWidth = f
         border-inline-start-width inlineStartWidth
     }
 
-    @supports not (border-block-end: 1rem solid red) {
+    @supports not (border-block-end 1rem solid red) {
         // The properties block/inline do not accept lists, so they are used as the side specific fallback
         // However, block/inline-color/style/width do accept lists so .nth is used to map the sides
         if (blockEnd || block) {
-            border-bottom blockEnd || block
+            border-bottom: blockEnd || block
         }
 
         if (blockEndColor || (blockColor[1])) {
-            border-bottom-color blockEndColor || (blockColor[1])
+            border-bottom-color: blockEndColor || (blockColor[1])
         }
 
         if (blockEndStyle || (blockStyle[1])) {
-            border-bottom-style blockEndStyle || (blockStyle[1])
+            border-bottom-style: blockEndStyle || (blockStyle[1])
         }
 
         if (blockEndWidth || (blockWidth[1])) {
-            border-bottom-width blockEndWidth || (blockWidth[1])
+            border-bottom-width: blockEndWidth || (blockWidth[1])
         }
 
         if (inlineStart || inline) {
-            border-left inlineStart || inline
+            border-left: inlineStart || inline
         }
 
         if (inlineStartColor || (inlineColor[0])) {
-            border-left-color inlineStartColor || (inlineColor[0])
+            border-left-color: inlineStartColor || (inlineColor[0])
         }
 
         if (inlineStartStyle || (inlineStyle[0])) {
-            border-left-style inlineStartStyle || (inlineStyle[0])
+            border-left-style: inlineStartStyle || (inlineStyle[0])
         }
 
         if (inlineStartWidth || (inlineWidth[0])) {
-            border-left-width inlineStartWidth || (inlineWidth[0])
+            border-left-width: inlineStartWidth || (inlineWidth[0])
         }
 
         if (inlineEnd || inline) {
-            border-right inlineEnd || inline
+            border-right: inlineEnd || inline
         }
 
         if (inlineEndColor || (inlineColor[1])) {
-            border-right-color inlineEndColor || (inlineColor[1])
+            border-right-color: inlineEndColor || (inlineColor[1])
         }
 
         if (inlineEndStyle || (inlineStyle[1])) {
-            border-right-style inlineEndStyle || (inlineStyle[1])
+            border-right-style: inlineEndStyle || (inlineStyle[1])
         }
 
         if (inlineEndWidth || (inlineWidth[1])) {
-            border-right-width inlineEndWidth || (inlineWidth[1])
+            border-right-width: inlineEndWidth || (inlineWidth[1])
         }
 
         if (blockStart || block) {
-            border-top blockStart || block
+            border-top: blockStart || block
         }
 
         if (blockStartColor || (blockColor[0])) {
-            border-top-color blockStartColor || (blockColor[0])
+            border-top-color: blockStartColor || (blockColor[0])
         }
 
         if (blockStartStyle || (blockStyle[0])) {
-            border-top-style blockStartStyle || (blockStyle[0])
+            border-top-style: blockStartStyle || (blockStyle[0])
         }
 
         if (blockStartWidth || (blockWidth[0])) {
-            border-top-width blockStartWidth || (blockWidth[0])
+            border-top-width: blockStartWidth || (blockWidth[0])
         }
     }
 }

--- a/packages/stylus/borderRadius.styl
+++ b/packages/stylus/borderRadius.styl
@@ -1,42 +1,42 @@
 // All props are optional and default to false
 border-radius(bottomLeft = false, bottomRight = false, radius = false, topLeft = false, topRight = false) {
     // General value that apply to more than one side
-    if radius {
+    if (radius) {
         border-radius radius
     }
 
     // Side specific values to overwrite any general values
-    if bottomRight {
+    if (bottomRight) {
         border-end-end-radius bottomRight
     }
 
-    if bottomLeft {
+    if (bottomLeft) {
         border-end-start-radius bottomLeft
     }
 
-    if topRight {
+    if (topRight) {
         border-start-end-radius topRight
     }
 
-    if topLeft {
+    if (topLeft) {
         border-start-start-radius topLeft
     }
 
     @supports not (border-end-end-radius 1rem) {
         // Side-specific fallbacks to override any general values
-        if bottomRight {
+        if (bottomRight) {
             border-bottom-right-radius bottomRight
         }
 
-        if bottomLeft {
+        if (bottomLeft) {
             border-bottom-left-radius bottomLeft
         }
 
-        if topRight {
+        if (topRight) {
             border-top-right-radius topRight
         }
 
-        if topLeft {
+        if (topLeft) {
             border-top-left-radius topLeft
         }
     }

--- a/packages/stylus/index.styl
+++ b/packages/stylus/index.styl
@@ -1,4 +1,5 @@
-@import 'border';
-@import 'borderRadius';
-@import 'margin';
-@import 'padding';
+@import 'border'
+@import 'borderRadius'
+@import 'margin'
+@import 'padding'
+@import 'position'

--- a/packages/stylus/margin.styl
+++ b/packages/stylus/margin.styl
@@ -2,63 +2,63 @@
 margin(block = false, blockEnd = false, blockStart = false, inline = false, inlineEnd = false, inlineStart = false, margin = false, scroll = false, scrollBlock = false, scrollBlockEnd = false, scrollBlockStart = false, scrollInline = false, scrollInlineEnd = false, scrollInlineStart = false) {
   // Wrap each property in a conditional to avoid empty/invalid styles from being generated
   // General value that apply to more than one side
-  if margin {
+  if (margin) {
     margin margin
   }
 
-  if block {
+  if (block) {
     margin-block block
   }
 
-  if inline {
+  if (inline) {
     margin-inline inline
   }
 
   // Side specific values to overwrite any general or axis values
-  if blockEnd {
+  if (blockEnd) {
     margin-block-end blockEnd
   }
 
-  if blockStart {
+  if (blockStart) {
     margin-block-start blockStart
   }
 
-  if inlineEnd {
+  if (inlineEnd) {
     margin-inline-end inlineEnd
   }
 
-  if inlineStart {
+  if (inlineStart) {
     margin-inline-start inlineStart
   }
 
   // General scroll values that apply to more than one side
-  if scroll {
+  if (scroll) {
     scroll-margin scroll
   }
 
   // Axis specific values to apply to two sides
-  if scrollBlock {
+  if (scrollBlock) {
     scroll-margin-block scrollBlock
   }
 
-  if scrollInline {
+  if (scrollInline) {
     scroll-margin-inline scrollInline
   }
 
   // Side specific scroll values to overwrite any general or axis values
-  if scrollBlockEnd {
+  if (scrollBlockEnd) {
     scroll-margin-block-end scrollBlockEnd
   }
 
-  if scrollBlockStart {
+  if (scrollBlockStart) {
     scroll-margin-block-start scrollBlockStart
   }
 
-  if scrollInlineEnd {
+  if (scrollInlineEnd) {
     scroll-margin-inline-end scrollInlineEnd
   }
 
-  if scrollInlineStart {
+  if (scrollInlineStart) {
     scroll-margin-inline-start scrollInlineStart
   }
 

--- a/packages/stylus/padding.styl
+++ b/packages/stylus/padding.styl
@@ -2,63 +2,63 @@
 padding(block = false, blockEnd = false, blockStart = false, inline = false, inlineEnd = false, inlineStart = false, padding = false, scroll = false, scrollBlock = false, scrollBlockEnd = false, scrollBlockStart = false, scrollInline = false, scrollInlineEnd = false, scrollInlineStart = false) {
   // Wrap each property in a conditional to avoid empty/invalid styles from being generated
   // General value that apply to more than one side
-  if padding {
+  if (padding) {
     padding padding
   }
 
-  if block {
+  if (block) {
     padding-block block
   }
 
-  if inline {
+  if (inline) {
     padding-inline inline
   }
 
   // Side specific values to overwrite any general or axis values
-  if blockEnd {
+  if (blockEnd) {
     padding-block-end blockEnd
   }
 
-  if blockStart {
+  if (blockStart) {
     padding-block-start blockStart
   }
 
-  if inlineEnd {
+  if (inlineEnd) {
     padding-inline-end inlineEnd
   }
 
-  if inlineStart {
+  if (inlineStart) {
     padding-inline-start inlineStart
   }
 
   // General scroll values that apply to more than one side
-  if scroll {
+  if (scroll) {
     scroll-padding scroll
   }
 
   // Axis specific values to apply to two sides
-  if scrollBlock {
+  if (scrollBlock) {
     scroll-padding-block scrollBlock
   }
 
-  if scrollInline {
+  if (scrollInline) {
     scroll-padding-inline scrollInline
   }
 
   // Side specific scroll values to overwrite any general or axis values
-  if scrollBlockEnd {
+  if (scrollBlockEnd) {
     scroll-padding-block-end scrollBlockEnd
   }
 
-  if scrollBlockStart {
+  if (scrollBlockStart) {
     scroll-padding-block-start scrollBlockStart
   }
 
-  if scrollInlineEnd {
+  if (scrollInlineEnd) {
     scroll-padding-inline-end scrollInlineEnd
   }
 
-  if scrollInlineStart {
+  if (scrollInlineStart) {
     scroll-padding-inline-start scrollInlineStart
   }
 

--- a/packages/stylus/position.styl
+++ b/packages/stylus/position.styl
@@ -1,0 +1,95 @@
+@import './utils/maps'
+
+// All props are optional and default to false
+position(blockEnd = false, blockStart = false, float = false, inlineEnd = false, inlineStart = false, inset = false) {
+    // Get possible inset list length to manually map to @supports fallbacks
+    insetLength = length(inset)
+
+    // If float is a directional value, map it to use its logical equivalent
+    if (float == left || (float == right)) {
+        float: logicalMap[float]
+    } else if (float) {
+        // Else use the raw float value(eg: none, unset, start ...)
+        float float
+    }
+
+    // General value that apply to more than one side
+    if (inset) {
+        inset inset
+    }
+
+    // Side specific scroll values to overwrite any general values
+    if (blockEnd) {
+        inset-block-end blockEnd
+    }
+
+    if (blockStart) {
+        inset-block-start blockStart
+    }
+
+    if (inlineEnd) {
+        inset-inline-end inlineEnd
+    }
+
+    if (inlineStart) {
+        inset-inline-start inlineStart
+    }
+
+    // FLOAT FALLBACK
+    // Because the inset property doesn't have a direct fallback equivalent
+    // the $inset values are manually mapped to their directional side
+    @supports not (float inline-end) {
+        if (float == inline-end || (float == inline-start)) {
+            float: logicalMap[float]
+        } else if (float) {
+            float float
+        }
+    }
+
+    // INSET FALLBACK
+    // Because the inset property doesn't have a direct fallback equivalent
+    // the $inset values are manually mapped to their directional side
+    @supports not (inset 1rem) {
+        if (inset && (insetLength == 1)) {
+            bottom: inset[0]
+            left: inset[0]
+            right: inset[0]
+            top: inset[0]
+        } else if (insetLength == 2) {
+            bottom: inset[0]
+            left: inset[1]
+            right: inset[1]
+            top: inset[0]
+        } else if (insetLength == 3) {
+            bottom: inset[2]
+            left: inset[1]
+            right: inset[1]
+            top: inset[0]
+        } else if (insetLength == 4) {
+            bottom: inset[2]
+            left: inset[3]
+            right: inset[1]
+            top: inset[0]
+        }
+    }
+
+    // SIDE-SPECIFIC FALLBACKS
+    // These will override any values from the inset fallback
+    @supports not (inset-block-end 1rem) {
+        if (blockEnd) {
+            bottom blockEnd
+        }
+
+        if (inlineStart) {
+            left inlineStart
+        }
+
+        if (inlineEnd) {
+            right inlineEnd
+        }
+
+        if (blockStart) {
+            top blockStart
+        }
+    }
+}

--- a/packages/stylus/utils/maps.styl
+++ b/packages/stylus/utils/maps.styl
@@ -1,0 +1,20 @@
+alignmentMap = {
+    left: start,
+    right: end,
+    start: left,
+    end: right
+}
+logicalMap = {
+    inline-end: right,
+    inline-start: left,
+    left: inline-start,
+    right: inline-end,
+    block-end: bottom,
+    block-start: top,
+    block: vertical,
+    bottom: block-end,
+    horizontal: inline,
+    inline: horizontal,
+    vertical: block,
+    top: block-start
+}


### PR DESCRIPTION
## 🔐 Closes

N/A

## 🚀 Changes

- adds position mixin to stylus package
- adds position import to root index file
- runs other mixins through save formatting
- adds maps utils

## ⛳️ Testing

- wrote and tested mixin at [Try Stylus](https://stylus-lang.com/try.html#?code=logicalMap%20%3D%20%7B%0A%20%20%20%20inline-end%3A%20right%2C%0A%20%20%20%20inline-start%3A%20left%2C%0A%20%20%20%20left%3A%20inline-start%2C%0A%20%20%20%20right%3A%20inline-end%2C%0A%20%20%20%20block-end%3A%20bottom%2C%0A%20%20%20%20block-start%3A%20top%2C%0A%20%20%20%20block%3A%20vertical%2C%0A%20%20%20%20bottom%3A%20block-end%2C%0A%20%20%20%20horizontal%3A%20inline%2C%0A%20%20%20%20inline%3A%20horizontal%2C%0A%20%20%20%20vertical%3A%20block%2C%0A%20%20%20%20top%3A%20block-start%0A%7D%0A%0A%2F%2F%20All%20props%20are%20optional%20and%20default%20to%20false%0Aposition(blockEnd%20%3D%20false%2C%20blockStart%20%3D%20false%2C%20float%20%3D%20false%2C%20inlineEnd%20%3D%20false%2C%20inlineStart%20%3D%20false%2C%20inset%20%3D%20false)%20%7B%0A%20%20%20%20%2F%2F%20Get%20possible%20inset%20list%20length%20to%20manually%20map%20to%20%40supports%20fallbacks%0A%20%20%20%20insetLength%20%3D%20length(inset)%0A%0A%20%20%20%20%2F%2F%20If%20float%20is%20a%20directional%20value%2C%20map%20it%20to%20use%20its%20logical%20equivalent%0A%20%20%20%20if%20(float%20%3D%3D%20left%20%7C%7C%20(float%20%3D%3D%20right))%20%7B%0A%20%20%20%20%20%20%20%20float%3A%20logicalMap%5Bfloat%5D%0A%20%20%20%20%7D%20else%20if%20(float)%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Else%20use%20the%20raw%20float%20value(eg%3A%20none%2C%20unset%2C%20start%20...)%0A%20%20%20%20%20%20%20%20float%20float%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%20General%20value%20that%20apply%20to%20more%20than%20one%20side%0A%20%20%20%20if%20(inset)%20%7B%0A%20%20%20%20%20%20%20%20inset%20inset%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%20Side%20specific%20scroll%20values%20to%20overwrite%20any%20general%20values%0A%20%20%20%20if%20(blockEnd)%20%7B%0A%20%20%20%20%20%20%20%20inset-block-end%20blockEnd%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(blockStart)%20%7B%0A%20%20%20%20%20%20%20%20inset-block-start%20blockStart%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(inlineEnd)%20%7B%0A%20%20%20%20%20%20%20%20inset-inline-end%20inlineEnd%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(inlineStart)%20%7B%0A%20%20%20%20%20%20%20%20inset-inline-start%20inlineStart%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%20FLOAT%20FALLBACK%0A%20%20%20%20%2F%2F%20Because%20the%20inset%20property%20doesn't%20have%20a%20direct%20fallback%20equivalent%0A%20%20%20%20%2F%2F%20the%20%24inset%20values%20are%20manually%20mapped%20to%20their%20directional%20side%0A%20%20%20%20%40supports%20not%20(float%20inline-end)%20%7B%0A%20%20%20%20%20%20%20%20if%20(float%20%3D%3D%20inline-end%20%7C%7C%20(float%20%3D%3D%20inline-start))%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20float%3A%20logicalMap%5Bfloat%5D%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20(float)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20float%20float%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%20INSET%20FALLBACK%0A%20%20%20%20%2F%2F%20Because%20the%20inset%20property%20doesn't%20have%20a%20direct%20fallback%20equivalent%0A%20%20%20%20%2F%2F%20the%20%24inset%20values%20are%20manually%20mapped%20to%20their%20directional%20side%0A%20%20%20%20%40supports%20not%20(inset%201rem)%20%7B%0A%20%20%20%20%20%20%20%20if%20(inset%20%26%26%20(insetLength%20%3D%3D%201))%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20bottom%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20left%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20right%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20top%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20(insetLength%20%3D%3D%202)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20bottom%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20left%3A%20inset%5B1%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20right%3A%20inset%5B1%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20top%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20(insetLength%20%3D%3D%203)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20bottom%3A%20inset%5B2%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20left%3A%20inset%5B1%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20right%3A%20inset%5B1%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20top%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%7D%20else%20if%20(insetLength%20%3D%3D%204)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20bottom%3A%20inset%5B2%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20left%3A%20inset%5B3%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20right%3A%20inset%5B1%5D%0A%20%20%20%20%20%20%20%20%20%20%20%20top%3A%20inset%5B0%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20%2F%2F%20SIDE-SPECIFIC%20FALLBACKS%0A%20%20%20%20%2F%2F%20These%20will%20override%20any%20values%20from%20the%20inset%20fallback%0A%20%20%20%20%40supports%20not%20(inset-block-end%201rem)%20%7B%0A%20%20%20%20%20%20%20%20if%20(blockEnd)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20bottom%20blockEnd%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(inlineStart)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20left%20inlineStart%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(inlineEnd)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20right%20inlineEnd%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(blockStart)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20top%20blockStart%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%0A%0A.container%20%7B%0A%20position(inset%3A%201rem%202rem%203rem%204rem%2C%20float%3A%20left%2C%20blockEnd%3A%201rem%2C%20inlineStart%3A%202rem)%0A%7D) to verify output
