### PR TITLE
feat: add layout mixin to stylus package

### DIFF
--- a/packages/stylus/border.styl
+++ b/packages/stylus/border.styl
@@ -1,5 +1,6 @@
 // All props are optional and default to false
 border(border = false, borderColor = false, borderStyle = false, borderWidth = false, block = false, blockColor = false, blockStyle = false, blockWidth = false, blockEnd = false, blockEndColor = false, blockEndStyle = false, blockEndWidth = false, blockStart = false, blockStartColor = false, blockStartStyle = false, blockStartWidth = false, inline = false, inlineColor = false, inlineStyle = false, inlineWidth = false, inlineEnd = false, inlineEndColor = false, inlineEndStyle = false, inlineEndWidth = false, inlineStart = false, inlineStartColor = false, inlineStartStyle = false, inlineStartWidth = false) {
+    // Wrap each property in a conditional to avoid empty/invalid styles from being generated
     // General value that apply to more than one side
     if (border) {
         border border

--- a/packages/stylus/borderRadius.styl
+++ b/packages/stylus/borderRadius.styl
@@ -1,5 +1,6 @@
 // All props are optional and default to false
 border-radius(bottomLeft = false, bottomRight = false, radius = false, topLeft = false, topRight = false) {
+    // Wrap each property in a conditional to avoid empty/invalid styles from being generated
     // General value that apply to more than one side
     if (radius) {
         border-radius radius

--- a/packages/stylus/index.styl
+++ b/packages/stylus/index.styl
@@ -1,5 +1,6 @@
 @import 'border'
 @import 'borderRadius'
+@import 'layout'
 @import 'margin'
 @import 'padding'
 @import 'position'

--- a/packages/stylus/layout.styl
+++ b/packages/stylus/layout.styl
@@ -1,0 +1,171 @@
+@import './utils/maps'
+
+// All props are optional and default to false
+layout(blockSize = false, captionSide = false, clear = false, inlineSize = false, maxBlockSize = false, maxInlineSize = false, minBlockSize = false, minInlineSize = false, overflow = false, overflowBlock = false, overflowInline = false, overscrollBehavior = false, overscrollBehaviorBlock = false, overscrollBehaviorInline = false, resize = false, textAlign = false) {
+    // Wrap each property in a conditional to avoid empty/invalid styles from being generated
+    if (captionSide == top || (captionSide == bottom)) {
+        caption-side: logicalMap[captionSide]
+    } else if (captionSide) {
+        caption-side captionSide
+    }
+
+    if (clear == left || (clear == right)) {
+        clear: logicalMap[clear]
+    } else if (clear) {
+        clear clear
+    }
+
+    if (resize == horizontal || (resize == vertical)) {
+        resize: logicalMap[resize]
+    } else if (resize) {
+        resize resize
+    }
+
+    if (textAlign == left || (textAlign == right)) {
+        text-align: alignmentMap[textAlign]
+    } else if (textAlign) {
+        text-align textAlign
+    }
+
+    if (blockSize) {
+        block-size blockSize
+    }
+
+    if (maxBlockSize) {
+        max-block-size maxBlockSize
+    }
+
+    if (minBlockSize) {
+        min-block-size minBlockSize
+    }
+
+    if (inlineSize) {
+        inline-size inlineSize
+    }
+
+    if (maxInlineSize) {
+        max-inline-size maxInlineSize
+    }
+
+    if (minInlineSize) {
+        min-inline-size minInlineSize
+    }
+
+    if (overflow) {
+        overflow overflow
+    }
+
+    if (overflowBlock) {
+        overflow-block overflowBlock
+    }
+
+    if (overflowInline) {
+        overflow-inline overflowInline
+    }
+
+    if (overscrollBehavior) {
+        overscroll-behavior overscrollBehavior
+    }
+
+    if (overscrollBehaviorBlock) {
+        overscroll-behavior-block overscrollBehaviorBlock
+    }
+
+    if (overscrollBehaviorInline) {
+        overscroll-behavior-inline overscrollBehaviorInline
+    }
+
+    @supports not (caption-side block-start) {
+        // If captionSide is a logical value, map it to its directional value fallback
+        if (captionSide == block-start || (captionSide == block-end)) {
+            caption-side: logicalMap[captionSide]
+        } else if (captionSide) {
+            // Else use the raw captionSide value
+            caption-side captionSide
+        }
+    }
+
+    @supports not (clear inline-start) {
+        if (clear == inline-start || (clear == inline-end)) {
+            // If clear is a logical value, map it to its directional value fallback
+            clear: logicalMap[clear]
+        } else if (clear) {
+            // Else use the raw clear value
+            clear clear
+        }
+    }
+
+    @supports not (resize block) {
+        if (logicalMap[resize]) {
+            // If the resize value isn't in the logical map, we don't need a fallback
+            if (resize == inline || (resize == block)) {
+                // If resize is a logical value, map it to its directional value fallback
+                resize: logicalMap[resize]
+            } else if (resize) {
+                // Else use the raw resize value
+                resize resize
+            }
+        }
+    }
+
+    @supports not (text-align start) {
+        if (alignmentMap[textAlign]) {
+            // If the textAlign value isn't in the logical map, we don't need a fallback
+            if (textAlign == start || (textAlign == end)) {
+                // If textAlign is a logical value, map it to its directional value fallback
+                text-align: alignmentMap[textAlign]
+            } else if (textAlign) {
+                // Else use the raw textAlign value
+                text-align textAlign
+            }
+        }
+    }
+
+    @supports not (block-size 1rem) {
+        if (blockSize) {
+            height blockSize
+        }
+
+        if (maxBlockSize) {
+            max-height maxBlockSize
+        }
+
+        if (minBlockSize) {
+            min-height minBlockSize
+        }
+    }
+
+    @supports not (inline-size 1rem) {
+        if (inlineSize) {
+            width inlineSize
+        }
+
+        if (maxInlineSize) {
+            max-width maxInlineSize
+        }
+
+        if (minInlineSize) {
+            min-width minInlineSize
+        }
+    }
+
+    @supports not (overflow-block auto) {
+        if (overflowInline) {
+            overflow-x overflowInline
+        }
+
+        if (overflowBlock) {
+            overflow-y overflowBlock
+        }
+    }
+
+    @supports not (overscroll-behavior-block auto) {
+        if (overscrollBehaviorInline) {
+            overscroll-behavior-x overscrollBehaviorInline
+        }
+
+        if (overscrollBehaviorBlock) {
+            overscroll-behavior-y overscrollBehaviorBlock
+        }
+    }
+}

--- a/packages/stylus/position.styl
+++ b/packages/stylus/position.styl
@@ -2,6 +2,7 @@
 
 // All props are optional and default to false
 position(blockEnd = false, blockStart = false, float = false, inlineEnd = false, inlineStart = false, inset = false) {
+    // Wrap each property in a conditional to avoid empty/invalid styles from being generated
     // Get possible inset list length to manually map to @supports fallbacks
     insetLength = length(inset)
 


### PR DESCRIPTION
## 🔐 Closes

N/A

## 🚀 Changes

- adds layout mixin to the stylus package
- adds layout mixin to root index file
- aligns stylus mixin comments

## ⛳️ Testing

- wrote and tested mixin at [Try Stylus](https://stylus-lang.com/try.html#?code=alignmentMap%20%3D%20%7B%0A%20%20%20%20left%3A%20start%2C%0A%20%20%20%20right%3A%20end%2C%0A%20%20%20%20start%3A%20left%2C%0A%20%20%20%20end%3A%20right%0A%7D%0AlogicalMap%20%3D%20%7B%0A%20%20%20%20inline-end%3A%20right%2C%0A%20%20%20%20inline-start%3A%20left%2C%0A%20%20%20%20left%3A%20inline-start%2C%0A%20%20%20%20right%3A%20inline-end%2C%0A%20%20%20%20block-end%3A%20bottom%2C%0A%20%20%20%20block-start%3A%20top%2C%0A%20%20%20%20block%3A%20vertical%2C%0A%20%20%20%20bottom%3A%20block-end%2C%0A%20%20%20%20horizontal%3A%20inline%2C%0A%20%20%20%20inline%3A%20horizontal%2C%0A%20%20%20%20vertical%3A%20block%2C%0A%20%20%20%20top%3A%20block-start%0A%7D%0A%0A%2F%2F%20All%20props%20are%20optional%20and%20default%20to%20false%0Alayout(blockSize%20%3D%20false%2C%20captionSide%20%3D%20false%2C%20clear%20%3D%20false%2C%20inlineSize%20%3D%20false%2C%20maxBlockSize%20%3D%20false%2C%20maxInlineSize%20%3D%20false%2C%20minBlockSize%20%3D%20false%2C%20minInlineSize%20%3D%20false%2C%20overflow%20%3D%20false%2C%20overflowBlock%20%3D%20false%2C%20overflowInline%20%3D%20false%2C%20overscrollBehavior%20%3D%20false%2C%20overscrollBehaviorBlock%20%3D%20false%2C%20overscrollBehaviorInline%20%3D%20false%2C%20resize%20%3D%20false%2C%20textAlign%20%3D%20false)%20%7B%0A%20%20if%20captionSide%20is%20top%20or%20captionSide%20is%20bottom%20%7B%0A%20%20%20caption-side%20logicalMap%5BcaptionSide%5D%20%0A%20%20%7D%20else%20if%20captionSide%20%7B%0A%20%20%20caption-side%20captionSide%20%0A%20%20%7D%0A%20%20%0A%20%20if%20clear%20is%20left%20or%20clear%20is%20right%20%7B%0A%20%20%20clear%20logicalMap%5Bclear%5D%20%0A%20%20%7D%20else%20if%20clear%20%7B%0A%20%20%20%20clear%20clear%0A%20%20%7D%0A%20%20%0A%20%20if%20resize%20is%20horizontal%20or%20resize%20is%20vertical%20%7B%0A%20%20%20resize%20logicalMap%5Bresize%5D%20%0A%20%20%7D%20else%20if%20resize%20%7B%0A%20%20%20%20resize%20resize%0A%20%20%7D%0A%20%20%0A%20%20if%20textAlign%20is%20left%20or%20textAlign%20is%20right%20%7B%0A%20%20%20text-align%20alignmentMap%5BtextAlign%5D%20%0A%20%20%7D%20else%20if%20textAlign%20%7B%0A%20%20%20text-align%20textAlign%20%0A%20%20%7D%0A%20%20%0A%20%20if%20(blockSize)%20%7B%0A%20%20%20%20%20%20%20%20block-size%20blockSize%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(maxBlockSize)%20%7B%0A%20%20%20%20%20%20%20%20max-block-size%20maxBlockSize%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(minBlockSize)%20%7B%0A%20%20%20%20%20%20%20%20min-block-size%20minBlockSize%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(inlineSize)%20%7B%0A%20%20%20%20%20%20%20%20inline-size%20inlineSize%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(maxInlineSize)%20%7B%0A%20%20%20%20%20%20%20%20max-inline-size%20maxInlineSize%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(minInlineSize)%20%7B%0A%20%20%20%20%20%20%20%20min-inline-size%20minInlineSize%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(overflow)%20%7B%0A%20%20%20%20%20%20%20%20overflow%20overflow%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(overflowBlock)%20%7B%0A%20%20%20%20%20%20%20%20overflow-block%20overflowBlock%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(overflowInline)%20%7B%0A%20%20%20%20%20%20%20%20overflow-inline%20overflowInline%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(overscrollBehavior)%20%7B%0A%20%20%20%20%20%20%20%20overscroll-behavior%20overscrollBehavior%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(overscrollBehaviorBlock)%20%7B%0A%20%20%20%20%20%20%20%20overscroll-behavior-block%20overscrollBehaviorBlock%0A%20%20%20%20%7D%0A%0A%20%20%20%20if%20(overscrollBehaviorInline)%20%7B%0A%20%20%20%20%20%20%20%20overscroll-behavior-inline%20overscrollBehaviorInline%0A%20%20%20%20%7D%0A%20%20%0A%20%20%40supports%20not%20(caption-side%3A%20block-start)%20%7B%0A%20%20%20%20if%20captionSide%20is%20block-start%20or%20captionSide%20is%20block-end%20%7B%0A%20%20%20%20%20caption-side%20logicalMap%5BcaptionSide%5D%20%0A%20%20%20%20%7D%20else%20if%20captionSide%20%7B%0A%20%20%20%20%20caption-side%20captionSide%20%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%40supports%20not%20(clear%3A%20inline-start)%20%7B%0A%20%20%20if%20clear%20is%20inline-start%20or%20clear%20is%20inline-end%20%7B%0A%20%20%20%20%20clear%20logicalMap%5Bclear%5D%20%0A%20%20%20%20%7D%20else%20if%20clear%20%7B%0A%20%20%20%20%20%20clear%20clear%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%40supports%20not%20(resize%3A%20block)%20%7B%0A%20%20%20if%20logicalMap%5Bresize%5D%20%7B%0A%20%20%20%20%20%20if%20resize%20is%20inline%20or%20resize%20is%20block%20%7B%0A%20%20%20%20%20%20%20%20resize%20logicalMap%5Bresize%5D%0A%20%20%20%20%20%20%7D%20else%20if%20resize%20%7B%0A%20%20%20%20%20%20%20%20resize%20resize%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%40supports%20not%20(text-align%3A%20start)%20%7B%0A%20%20%20%20if%20alignmentMap%5BtextAlign%5D%20%7B%0A%20%20%20%20%20%20%0A%20%20%20if%20textAlign%20is%20start%20or%20textAlign%20is%20end%20%7B%0A%20%20%20%20%20text-align%20alignmentMap%5BtextAlign%5D%20%0A%20%20%20%20%7D%20else%20if%20textAlign%20%7B%0A%20%20%20%20%20text-align%20textAlign%20%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%7D%0A%0A%20%20%20%20%40supports%20not%20(block-size%201rem)%20%7B%0A%20%20%20%20%20%20%20%20if%20(blockSize)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20height%20blockSize%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(maxBlockSize)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20max-height%20maxBlockSize%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(minBlockSize)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20min-height%20minBlockSize%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20%40supports%20not%20(inline-size%201rem)%20%7B%0A%20%20%20%20%20%20%20%20if%20(inlineSize)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20width%20inlineSize%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(maxInlineSize)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20max-width%20maxInlineSize%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(minInlineSize)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20min-width%20minInlineSize%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20%40supports%20not%20(overflow-block%20auto)%20%7B%0A%20%20%20%20%20%20%20%20if%20(overflowInline)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20overflow-x%20overflowInline%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(overflowBlock)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20overflow-y%20overflowBlock%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%0A%20%20%20%20%40supports%20not%20(overscroll-behavior-block%20auto)%20%7B%0A%20%20%20%20%20%20%20%20if%20(overscrollBehaviorInline)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20overscroll-behavior-x%20overscrollBehaviorInline%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20if%20(overscrollBehaviorBlock)%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20overscroll-behavior-y%20overscrollBehaviorBlock%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%0A%0A.container%20%7B%0A%20%20layout(textAlign%3A%20start%2C%20captionSide%3A%20block-end%2C%20resize%3A%20both)%0A%7D) to verify output
